### PR TITLE
chore: upgrade titiler to 0.19.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-rio-tiler>=6.4.3
-titiler.application==0.18.6
-asyncpg==0.29.0
+rio-tiler>=7.2.2
+titiler.application==0.19.2
+asyncpg==0.30.0
 postgis==1.0.4
-uvicorn==0.30.6
+uvicorn==0.34.0
 boto3
 pyyaml
 gunicorn

--- a/src/cogserver/extensions/mosaicjson.py
+++ b/src/cogserver/extensions/mosaicjson.py
@@ -5,7 +5,7 @@ from cogeo_mosaic.mosaic import MosaicJSON
 from cogserver.dependencies import SignedDatasetPaths
 from fastapi import Depends, Query
 from pydantic import BaseModel
-from titiler.core.factory import BaseTilerFactory, FactoryExtension
+from titiler.core.factory import TilerFactory, FactoryExtension
 from titiler.core.resources.responses import JSONResponse
 from typing_extensions import Annotated
 
@@ -29,8 +29,8 @@ class MosaicJsonExtension(FactoryExtension):
             mosaicjson.attribution = attribution
         return mosaicjson
 
-    # Register method is mandatory and must take a BaseTilerFactory object as input
-    def register(self, factory: BaseTilerFactory):
+    # Register method is mandatory and must take a TilerFactory object as input
+    def register(self, factory: TilerFactory):
         @factory.router.get(
             "/build",
             response_model=MosaicJSON,

--- a/src/cogserver/vrt.py
+++ b/src/cogserver/vrt.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter
-from titiler.core.factory import MultiBaseTilerFactory
+from titiler.core.factory import TilerFactory
 
 
 router = APIRouter()
 
 
-class VRTFactory(MultiBaseTilerFactory):
+class VRTFactory(TilerFactory):
     """
-    Override the MultiBaseTilerFactory to add a VRT endpoint
+    Override the TilerFactory to add a VRT endpoint
     Empty register_routes method to override all routes and have no routes
     """
 


### PR DESCRIPTION
- upgrade titiler and rio-tiler to the latest
- fixed some breaking changes related to Factory since `BaseTilerFactory` was removed in the latest (split into BaseFactory and TilerFactory)

I tested titiler with geohub locally